### PR TITLE
Update BaseFixtureLoader.js

### DIFF
--- a/lib/BaseFixtureLoader.js
+++ b/lib/BaseFixtureLoader.js
@@ -32,12 +32,15 @@ module.exports = function(fixtureConfig, mongoose, rootCallback){
     var fixtureData = require(fixtureConfig.dataFixturePath+fixtureDataKey)(mongoose, function(err, globalFixtureData){
         var fixtureSet = null;
 
-        // globalFixtureData can be an array as a convience
+        // globalFixtureData can be a plain object or array as a convience
         // or it is a kwarg that contains a dataFixture namespace
-        if(_.isArray(globalFixtureData) == true){
-            fixtureSet = globalFixtureData;
-        } else {
+        if(_.isPlainObject(globalFixtureData) && globalFixtureData.dataFixtures){
             fixtureSet = globalFixtureData.dataFixtures;
+        } else if(_.isPlainObject(globalFixtureData)){
+            globalFixtureData = _.values(globalFixtureData);
+        }
+        if(_.isArray(globalFixtureData)){
+            fixtureSet = globalFixtureData;
         }
 
 

--- a/lib/BaseFixtureLoader.js
+++ b/lib/BaseFixtureLoader.js
@@ -34,15 +34,16 @@ module.exports = function(fixtureConfig, mongoose, rootCallback){
 
         // globalFixtureData can be a plain object or array as a convience
         // or it is a kwarg that contains a dataFixture namespace
-        if(_.isPlainObject(globalFixtureData) && globalFixtureData.dataFixtures){
-            fixtureSet = globalFixtureData.dataFixtures;
-        } else if(_.isPlainObject(globalFixtureData)){
-            globalFixtureData = _.values(globalFixtureData);
+        if(_.isPlainObject(globalFixtureData)){
+            if(globalFixtureData.dataFixtures){
+                fixtureSet = globalFixtureData.dataFixtures;
+            } else {
+                globalFixtureData = _.values(globalFixtureData);
+            }
         }
         if(_.isArray(globalFixtureData)){
             fixtureSet = globalFixtureData;
         }
-
 
         // make orm calls for each 'document' in the data-fixtiure
         // assumption is that data fixture will return an array of 'like' documents for the 


### PR DESCRIPTION
Accept a plain object for the `fixture` variable in the user fixtures file, by seamlessly converting to an array.
